### PR TITLE
add get image name functions and move rfunction names to constants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 GIT_ROOT=$(shell git rev-parse --show-toplevel)
-BASE_IMAGE_NAME=strong_network_base
+BASE_IMAGE_NAME=sn_base
+GOLANG_IMAGE_NAME=sn_golang
+PYTHON_SPARK_IMAGE_NAME=sn_python_spark
+PYTHON_DATASCIENCE_IMAGE_NAME=sn_python_datascience
+PYTHON_ANACONDA_IMAGE_NAME=sn_python_anaconda
+NODEJS_IMAGE_NAME=sn_nodejs
+GENERIC_IMAGE_NAME=sn_generic
+FLUTTER_IMAGE_NAME=sn_flutter
 VERSION = $(shell awk NF ${GIT_ROOT}/VERSION)
-GOLANG_IMAGE = strong_network_golang
 
 .PHONY: base_image
 base_image:
@@ -16,22 +22,54 @@ remove_base_image:
 
 .PHONY: golang_image
 golang_image: base_image
-	@docker build -t strong_network_golang:${VERSION} golang
+	@docker build -t ${GOLANG_IMAGE_NAME}:${VERSION} golang
 
 python_spark_image: base_image
-	@docker build -t strong_network_python_spark:${VERSION} python_spark
+	@docker build -t ${PYTHON_SPARK_IMAGE_NAME}:${VERSION} python_spark
 
 python_datascience_image: base_image
-	@docker build -t strong_network_python_datascience:${VERSION} python_datascience
+	@docker build -t ${PYTHON_DATASCIENCE_IMAGE_NAME}:${VERSION} python_datascience
 
 python_anaconda_image: base_image
-	@docker build -t strong_network_python_anaconda:${VERSION} python_anaconda
+	@docker build -t ${PYTHON_ANACONDA_IMAGE_NAME}:${VERSION} python_anaconda
 
 nodejs_image: base_image
-	@docker build -t strong_network_nodejs:${VERSION} nodejs
+	@docker build -t ${NODEJS_IMAGE_NAME}:${VERSION} nodejs
 
 generic_image: base_image
-	@docker build -t strong_network_generic:${VERSION} generic
+	@docker build -t ${GENERIC_IMAGE_NAME}:${VERSION} generic
 
 flutter_image: base_image
-	@docker build -t strong_network_flutter:${VERSION} flutter
+	@docker build -t ${FLUTTER_IMAGE_NAME}:${VERSION} flutter
+
+.PHONY: get_version
+get_version:
+	@echo ${VERSION}
+
+.PHONY: get_base_image
+get_base_image:
+	@echo ${BASE_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_golang_image
+get_golang_image:
+	@echo ${GOLANG_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_spark_image
+get_spark_image:
+	@echo ${PYTHON_SPARK_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_python_datascience_image
+get_python_datascience_image:
+	@echo ${PYTHON_DATASCIENCE_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_python_anaconda_image
+get_python_anaconda_image:
+	@echo ${PYTHON_ANACONDA_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_nodejs_image
+get_nodejs_image:
+	@echo ${NODEJS_IMAGE_NAME}:${VERSION}
+
+.PHONY: get_flutter_image
+get_flutter_image:
+	@echo ${FLUTTER_IMAGE_NAME}:${VERSION}


### PR DESCRIPTION
### Background
The provided image names were quite long and a bother to type(strong_network_[image descriptor]. there were also no provided methods for getting the names directly along with the image versions

### Changes
Rename the strong_network_ prefix of the image to sn_ and provide helper functions that give the image name for each image along with the latest version  

### Testing
Make sure that the images can still be built and that the image name functions print the correct name