### PR TITLE
[Images] Add deployement and build for an Intellij Ultimate image and rename the java intellij image

### DIFF
--- a/.github/workflows/push_images.yml
+++ b/.github/workflows/push_images.yml
@@ -22,6 +22,7 @@ jobs:
       PYCHARM_IMAGE_URL: ${{ secrets.REGISTRY }}/pycharm_python:${{ secrets.VERSION }}
       PHPSTORM_IMAGE_URL: ${{ secrets.REGISTRY }}/phpstorm_php:${{ secrets.VERSION }}
       ANDROID_IMAGE_URL: ${{ secrets.REGISTRY }}/android_studio:${{ secrets.VERSION }}
+      INTELLIJ_ULTIMATE_IMAGE_URL: ${{ secrets.REGISTRY }}/intellij_ultimate:${{ secrets.VERSION }}
 
     runs-on: ubuntu-latest
 
@@ -213,4 +214,18 @@ jobs:
         run:  docker push $ANDROID_IMAGE_URL
       
       - name: Remove Android Studio cloud editor image
+        run: docker rmi $(docker images -a | grep -v sn_base | grep -v IMAGE  |  awk {'print $3'}) || echo 'ignoring error'
+
+      # Build Intellij Ultimate
+
+      - name: Build the Intellij Ultimate image
+        run:  make intellij_ultimate
+
+      - name: Tag new intellij ultimate image
+        run: docker tag $(make get_intellij_ultimate_image) $INTELLIJ_ULTIMATE_IMAGE_URL
+
+      - name: Push the Intellij Ultimate image
+        run:  docker push $INTELLIJ_ULTIMATE_IMAGE_URL
+      
+      - name: Remove the Intellij Ultimate image url
         run: docker rmi $(docker images -a | grep -v sn_base | grep -v IMAGE  |  awk {'print $3'}) || echo 'ignoring error'

--- a/.github/workflows/push_images.yml
+++ b/.github/workflows/push_images.yml
@@ -17,7 +17,7 @@ jobs:
       PYTHON_DATASCIENCE_IMAGE_URL : ${{ secrets.REGISTRY }}/cloud_editor_python_datascience:${{ secrets.VERSION }}
       PYTHON_ANACONDA_IMAGE_URL: ${{ secrets.REGISTRY }}/cloud_editor_python_anaconda:${{ secrets.VERSION }}
       FLUTTER_IMAGE_URL: ${{ secrets.REGISTRY }}/cloud_editor_flutter:${{ secrets.VERSION }}
-      JAVA_INTELLIJ_IMAGE_URL: ${{ secrets.REGISTRY }}/cloud_editor_java_intellij:${{ secrets.VERSION }}
+      JAVA_INTELLIJ_IMAGE_URL: ${{ secrets.REGISTRY }}/intellij_java:${{ secrets.VERSION }}
       GOLAND_IMAGE_URL: ${{ secrets.REGISTRY }}/goland_go:${{ secrets.VERSION }}
       PYCHARM_IMAGE_URL: ${{ secrets.REGISTRY }}/pycharm_python:${{ secrets.VERSION }}
       PHPSTORM_IMAGE_URL: ${{ secrets.REGISTRY }}/phpstorm_php:${{ secrets.VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GOLAND_IMAGE_NAME=sn_goland
 PYCHARM_IMAGE_NAME=sn_pycharm
 PHPSTORM_IMAGE_NAME=sn_phpstorm
 ANDROID_STUDIO_IMAGE_NAME=sn_android_studio
+INTELLIJ_ULTIMATE_IMAGE_NAME=sn_intellij_ultimate
 VERSION = $(shell awk NF ${GIT_ROOT}/VERSION)
 
 .PHONY: base_image
@@ -72,6 +73,10 @@ phpstorm: base_jetbrains_image
 .PHONY: android_studio 
 android_studio: base_jetbrains_image
 	@docker build -t ${ANDROID_STUDIO_IMAGE_NAME}:${VERSION} android_studio
+
+.PHONY: intellij_ultimate
+intellij_ultimate: base_jetbrains_image
+	@docker build -t ${INTELLIJ_ULTIMATE_IMAGE_NAME}:${VERSION} intellij_ultimate
 
 .PHONY: all
 all: base_image base_jetbrains_image golang_image python_spark_image python_datascience_image python_anaconda_image nodejs_image generic_image flutter_image java_intellij goland pycharm phpstorm android_studio
@@ -134,4 +139,8 @@ get_phpstorm_image:
 
 .PHONY: get_android_studio_image
 get_android_studio_image:
-	@echo ${ANDROID_STUDIO_IMAGE_NAME}:${VERSION}
+	@echo ${ANDROID_STUDIO_IMAGE_NAME}:${VERSION} 
+
+.PHONY: get_intellij_ultimate_image
+get_intellij_ultimate_image:
+	@echo ${INTELLIJ_ULTIMATE_IMAGE_NAME}:${VERSION}

--- a/intellij_ultimate/Dockerfile
+++ b/intellij_ultimate/Dockerfile
@@ -1,0 +1,8 @@
+FROM sn_base_jetbrains
+
+COPY setup.sh /setup.sh
+
+RUN chmod +x /setup.sh && ./setup.sh && rm /setup.sh
+
+USER developer
+WORKDIR /home/developer

--- a/intellij_ultimate/setup.sh
+++ b/intellij_ultimate/setup.sh
@@ -1,0 +1,10 @@
+# Set the ide.tar.gz file
+wget -O /ide.tar.gz https://download.jetbrains.com/idea/ideaIU-2022.1.1.tar.gz
+/unzip_ide.sh
+
+DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install php libapache2-mod-php -y
+
+sudo rm -rf /var/lib/apt/lists/*
+sudo rm -rf /var/cache/apt
+
+chown -R developer:developer /ide/bin


### PR DESCRIPTION
### Background
In order to run JetBrains based editor, the given editor has to be included in the workspace image. Many clients use Intellij Ultimate for their development and there was no image available that had Intellij Ultimate pre-packaged. 

Additionally, the public name for the image that came pre-packaged with Intellij conflicted with the name used internally at Strong Network.

# Changes
Rename the java Intellij image and include an image with Intellij Ultimate pre-packaged.
